### PR TITLE
Updated cart and mineral selection to refresh upon changing of governor

### DIFF
--- a/scripts/Cart.js
+++ b/scripts/Cart.js
@@ -38,6 +38,7 @@ const findMineInventory = (mineId) => {
   return currentMineInventory;
 };
 
+
 let currentColony = null; //moved to modular scope
 const findMatchingColonyInventory = (colonyId, mineInventory) => {
   const colonyInventories = getColonyInventory();
@@ -78,10 +79,17 @@ const findMatchingColonyInventory = (colonyId, mineInventory) => {
 };
 
 let currentMineId = 0;
+
 export const cartUpdate = () => {
+
   const currentOrder = getCurrentOrder();
   let currentMineId = currentOrder.selectedMine;
   let currentMineralId = currentOrder.selectedMineral;
+  console.log(currentMineralId)
+  
+  if(currentMineralId === null){
+    return ""
+  }
 
   let currentMine = null;
   let currentMineral = null;

--- a/scripts/Colonies.js
+++ b/scripts/Colonies.js
@@ -1,4 +1,5 @@
-import { getGovernors, getColonies, setColonyId, getColonyInventory, getMineral } from "./database.js";
+import { cartUpdate } from "./Cart.js";
+import { getGovernors, getColonies, setColonyId, getColonyInventory, getMineral, setMineral, getCurrentOrder } from "./database.js";
 
 const governors = getGovernors()
 const colonies = getColonies()
@@ -69,6 +70,8 @@ document.addEventListener("change", (event) => {
         // parsing the selected value to get the selectedGovernorId
         let selectedGovernorId = parseInt(event.target.value)
         // If the selectedGovernorId is the placeholder (value 0), present placeholder name
+
+
         if (selectedGovernorId === 0) {
             document.querySelector("#colony--header").innerHTML = `<h2>Colony Minerals</h2>`
         } else {
@@ -76,8 +79,21 @@ document.addEventListener("change", (event) => {
             let currentColony = findColony(selectedGovernorId, colonies)
             setColonyId(currentColony.id)
             // show the current colony's name + Minerals as a header
+            
             document.querySelector("#colony--header").innerHTML = `<h2>${currentColony.name} Minerals</h2>`
             document.querySelector("#colony--inventory").innerHTML = renderColonyInventory(currentColony);
+        }
+    }
+})
+
+
+document.addEventListener("change", (event) => {
+    let currentOrder = getCurrentOrder();
+    if (event.target.id === "governor" && currentOrder.selectedMineral != null) {
+        if(document.querySelector("input[name='mineral']:checked").checked === true){
+            document.querySelector("input[name='mineral']:checked").checked = false
+            setMineral(null)
+            document.querySelector('#cart--inventory').innerHTML = cartUpdate()
         }
     }
 })


### PR DESCRIPTION
# Description

When governor is changed, no longer shows a selected mineral in the cart or facility minerals section.

Fixes #63  (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
